### PR TITLE
Change version number from 105.xxx to 1.n.m

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supportability-review-app",
   "description": "Supportability Review UI extension",
-  "version": "105.0.0-up0.1.0",
+  "version": "3.0.0",
   "private": false,
   "engines": {
     "node": ">=20"

--- a/pkg/supportability-review-app/package.json
+++ b/pkg/supportability-review-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "supportability-review-app",
   "description": "supportability-review-app plugin",
-  "version": "105.0.0-up0.1.0",
+  "version": "3.0.0",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
Resolves #56.

Previously we used trailing version.

- 105.xxx for Rancher 2.10
- 104.xxx for Rancher 2.9
- 103.xxx for Rancher 2.8

We will switch to these.

- 3.x.y for Rancher 2.10
- 2.x.y for Rancher 2.9
- 1.x.y for Rancher 2.8