### PR TITLE
Fix wrong format for `routes`

### DIFF
--- a/pkg/supportability-review-app/components/DashboardView.vue
+++ b/pkg/supportability-review-app/components/DashboardView.vue
@@ -25,7 +25,7 @@ export default {
   methods: {
     goToReviewBundle() {
       this.$router.push({
-        path: '/c/_/sr/sr.cattle.io.reviewbundle/create'
+        path: '/sr/c/_/sr.cattle.io.reviewbundle/create'
       });
     }
   }

--- a/pkg/supportability-review-app/models/sr.cattle.io.reviewbundle.js
+++ b/pkg/supportability-review-app/models/sr.cattle.io.reviewbundle.js
@@ -1,5 +1,4 @@
 import SteveModel from '@shell/plugins/steve/steve-class';
-import { createRoute } from '../utils/custom-routing';
 
 export default class ReviewBundle extends SteveModel {
   get _availableActions() {
@@ -39,8 +38,7 @@ export default class ReviewBundle extends SteveModel {
   }
 
   viewReport() {
-    const route = createRoute('report', {}, {});
-    window.location.href = `../${route.params.product}/view-report/${this.id}/?bundlename=${this.metadata.name}`;
+    window.location.href = `./view-report/${this.id}/?bundlename=${this.metadata.name}`;
   }
 
   downloadFromUrl(url, filename) {

--- a/pkg/supportability-review-app/pages/_resource/_id.vue
+++ b/pkg/supportability-review-app/pages/_resource/_id.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+export default {
+  name: 'SupportabilityReviewBundleResourceDetails',
+  components: { ResourceDetail }
+};
+</script>
+
+<template>
+  <ResourceDetail />
+</template>

--- a/pkg/supportability-review-app/pages/_resource/create.vue
+++ b/pkg/supportability-review-app/pages/_resource/create.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+import ResourceDetail from '@shell/components/ResourceDetail/index.vue';
+
+export default {
+  name: 'CreateSupportabilityReviewBundleResource',
+  components: { ResourceDetail }
+};
+</script>
+
+<template>
+  <ResourceDetail />
+</template>

--- a/pkg/supportability-review-app/pages/_resource/index.vue
+++ b/pkg/supportability-review-app/pages/_resource/index.vue
@@ -1,0 +1,21 @@
+<script>
+import ResourceList from '@shell/components/ResourceList/index.vue';
+import { SUPPORTABILITY_REVIEW_CRD_IDS } from '../../config/types';
+
+export default {
+  name: 'ListSupportabilityReviewBundleResource',
+  components: { ResourceList },
+  data() {
+    return {};
+  },
+  async fetch() {
+    // needed to populate cluster name col on machine inventories list
+    await this.$store.dispatch(`management/findAll`, { type: SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE });
+  },
+  computed: {}
+};
+</script>
+
+<template>
+  <ResourceList :has-advanced-filtering="advancedFilteringEnabled"></ResourceList>
+</template>

--- a/pkg/supportability-review-app/product.js
+++ b/pkg/supportability-review-app/product.js
@@ -3,10 +3,9 @@ import { SUPPORTABILITY_REVIEW_PRODUCT_NAME, SUPPORTABILITY_REVIEW_CRD_IDS, SR_A
 import { rootRoute, createRoute } from './utils/custom-routing';
 
 export function init($plugin, store) {
-  const { product, configureType, virtualType, basicType, headers } = $plugin.DSL(
+  const { product, configureType, virtualType, basicType, weightType, headers } = $plugin.DSL(
     store,
     SUPPORTABILITY_REVIEW_PRODUCT_NAME
-    // SUPPORTABILITY_REVIEW_PRODUCT_FULL_NAME,
   );
 
   function getBundleSizeString(row) {
@@ -39,18 +38,19 @@ export function init($plugin, store) {
 
   // dashboard menu entry in SR App
   virtualType({
-    labelKey: 'sr.menuLabels.dashboard',
-    // label: store.getters["i18n/t"]("sr.menuLabels.dashboard"),
+    label: store.getters['i18n/t']('sr.menuLabels.dashboard'),
     name: SR_APP_PAGES.DASHBOARD,
+    weight: 10,
     route: rootRoute()
   });
 
   // defining a k8s resource as page
+  weightType(SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE, 9, true);
   configureType(SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE, {
-    displayName: store.getters['i18n/t'](`typeLabel."${SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE}"`),
     isCreatable: true,
     isEditable: false,
-    isRemovable: true
+    isRemovable: true,
+    customRoute: createRoute('resource', { resource: SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE })
   });
   headers(SUPPORTABILITY_REVIEW_CRD_IDS.REVIEW_BUNDLE, [
     STATE,

--- a/pkg/supportability-review-app/routing/sr-routing.js
+++ b/pkg/supportability-review-app/routing/sr-routing.js
@@ -1,14 +1,14 @@
-import ListResource from '@shell/pages/c/_cluster/_product/_resource/index.vue';
-import CreateResource from '@shell/pages/c/_cluster/_product/_resource/create.vue';
-import ViewResource from '@shell/pages/c/_cluster/_product/_resource/_id.vue';
+import ListResource from '../pages/_resource/index.vue';
+import CreateResource from '../pages/_resource/create.vue';
+import ViewResource from '../pages/_resource/_id.vue';
 import Dashboard from '../pages/DashboardPage.vue';
 import ViewReportPage from '../pages/ViewReportPage';
 import { SUPPORTABILITY_REVIEW_PRODUCT_NAME, BLANK_CLUSTER } from '../config/types';
 
 const routes = [
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/dashboard`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/dashboard`,
     component: Dashboard,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
@@ -17,8 +17,8 @@ const routes = [
     }
   },
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-view-report`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/view-report`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster-view-report`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/view-report`,
     component: ViewReportPage,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
@@ -27,8 +27,8 @@ const routes = [
     }
   },
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-view-report`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/view-report/:id/:report?`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster-view-report`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/view-report/:id/:report?`,
     component: ViewReportPage,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
@@ -40,8 +40,8 @@ const routes = [
   // the following routes cover the "resource page"
   // registering routes for list/edit/create views
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-resource`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/:resource`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster-resource`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/:resource`,
     component: ListResource,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
@@ -49,8 +49,8 @@ const routes = [
     }
   },
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-resource-create`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/:resource/create`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster-resource-create`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/:resource/create`,
     component: CreateResource,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
@@ -58,8 +58,8 @@ const routes = [
     }
   },
   {
-    name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-resource-id`,
-    path: `/c/:cluster/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/:resource/:id`,
+    name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster-resource-id`,
+    path: `/${SUPPORTABILITY_REVIEW_PRODUCT_NAME}/c/:cluster/:resource/:id`,
     component: ViewResource,
     meta: {
       product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,

--- a/pkg/supportability-review-app/utils/custom-routing.ts
+++ b/pkg/supportability-review-app/utils/custom-routing.ts
@@ -1,7 +1,7 @@
 import { SUPPORTABILITY_REVIEW_PRODUCT_NAME, BLANK_CLUSTER } from '../config/types';
 
 export const rootRoute = () => ({
-  name: `c-cluster-${SUPPORTABILITY_REVIEW_PRODUCT_NAME}`,
+  name: `${SUPPORTABILITY_REVIEW_PRODUCT_NAME}-c-cluster`,
   params: {
     product: SUPPORTABILITY_REVIEW_PRODUCT_NAME,
     cluster: BLANK_CLUSTER


### PR DESCRIPTION
Resolves #61.

Should be `PRODUCT-C-CLUSTER…` for top-level products. https://extensions.rancher.io/extensions/next/api/nav/routing#routes-definition-for-an-extension-as-a-top-level-product