### PR TITLE
Update workflow reference and permissions in YAML

### DIFF
--- a/.github/workflows/build-extension-charts.yml
+++ b/.github/workflows/build-extension-charts.yml
@@ -12,12 +12,10 @@ defaults:
 
 jobs:
   build-extension-charts:
-    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@57fc3a25fd4e433e7bd7ee6c1793703c1a2f95a0 # 2026-04-09
+    uses: rancher/dashboard/.github/workflows/build-extension-charts.yml@9bf23dff6650116673346447bcf0b088e0edb27f # creators-pkg-v3.0.12
     permissions:
-      actions: write
       contents: write
-      deployments: write
-      pages: write
+      pull-requests: write
     with:
       target_branch: gh-pages
       tagged_release: ${{ github.ref_name }}


### PR DESCRIPTION
Updates were done on the reusable workflow https://github.com/rancher/dashboard/blob/master/.github/workflows/build-extension-charts.yml in terms of security hardening, reducing the set of permissions needed to the minimum required for the workflow to run.

With that change in mind, we've done testing on `elemental-ui` with this new version https://github.com/rancher/elemental-ui/blob/main/.github/workflows/build-extension-charts.yml#L15 + https://github.com/rancher/elemental-ui/actions/runs/28600678629 and we will need to update all the official extensions repositories to consume this new version/hash of the workflow